### PR TITLE
Wire up pagination on the Frontend to the API

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -4,6 +4,7 @@ import "./App.css";
 import SearchGateway from "./Gateway/SearchGateway";
 import SearchAssets from "./UseCase/SearchAssets";
 
+import Pagination from './Components/Pagination'
 import AssetsProvider from "./Components/AssetsProvider";
 import SearchBox from "./Components/SearchBox";
 import AssetList from "./Components/AssetList";
@@ -16,10 +17,15 @@ class App extends Component {
     return (
       <div>
         <AssetsProvider searchAssets={searchAssetUsecase}>
-          {({ assets, onSearch }) => (
+          {({ assets, onSearch, onPageSelect, numberOfPages, currentPage }) => (
             <div>
               <SearchBox onSearch={onSearch} />
               <AssetList assets={assets} />
+              <Pagination
+                onPageSelect={onPageSelect}
+                max={numberOfPages}
+                current={currentPage}
+              />
             </div>
           )}
         </AssetsProvider>

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -15,6 +15,7 @@ describe("When rendering the app", () => {
 
     searchAssetSimulator
       .searchAssetWithFilters({ schemeId: "1", address: "Fake Street" })
+      .searchAssetWithPage(1)
       .respondWithAssets([exampleAssetOne])
       .successfully();
 
@@ -39,8 +40,8 @@ describe("When rendering the app", () => {
     expect(
       renderedAsset.find({ "data-test": "asset-scheme-id" }).text()
     ).toEqual("12345");
-    expect(
-      renderedAsset.find({ "data-test": "asset-address" }).text()
-    ).toEqual("123 Fake Street");
+    expect(renderedAsset.find({ "data-test": "asset-address" }).text()).toEqual(
+      "123 Fake Street"
+    );
   });
 });

--- a/src/Components/AssetsProvider/index.js
+++ b/src/Components/AssetsProvider/index.js
@@ -3,12 +3,29 @@ import React, { Component } from "react";
 export default class AssetsProvider extends Component {
   constructor() {
     super();
-    this.state = { assets: [] };
+    this.state = {
+      assets: [],
+      page: 1,
+      searchParameters: {},
+      pages: 0
+    };
   }
 
   onSearch = async searchRequest => {
-    let { assets } = await this.props.searchAssets.execute(searchRequest);
-    this.setState({ assets });
+    let { assets, pages } = await this.props.searchAssets.execute({
+      ...searchRequest,
+      page: 1
+    });
+    this.setState({ searchParameters: searchRequest, assets, pages, page: 1 });
+  };
+
+  onPageSelect = async ({ page }) => {
+    let { assets } = await this.props.searchAssets.execute({
+      ...this.state.searchParameters,
+      page
+    });
+
+    this.setState({ page, assets });
   };
 
   render() {
@@ -16,7 +33,10 @@ export default class AssetsProvider extends Component {
       <div>
         {this.props.children({
           onSearch: this.onSearch,
-          assets: this.state.assets
+          onPageSelect: this.onPageSelect,
+          assets: this.state.assets,
+          numberOfPages: this.state.pages,
+          currentPage: this.state.page
         })}
       </div>
     );

--- a/src/Components/Pagination/index.js
+++ b/src/Components/Pagination/index.js
@@ -3,17 +3,17 @@ import "./style.css";
 
 export default class Pagination extends Component {
   renderFirstButton = () => {
-    if (this.props.current == 1) {
+    if (this.props.current === 1) {
       return <span />;
     } else {
       return (
-        <a
+        <span
           className="pagination-link"
           data-test="pagination-first-page"
           onClick={() => this.props.onPageSelect({ page: 1 })}
         >
           1
-        </a>
+        </span>
       );
     }
   };
@@ -23,7 +23,7 @@ export default class Pagination extends Component {
       return <span />;
     } else {
       return (
-        <a
+        <span
           className="pagination-link"
           data-test="pagination-left-jump"
           onClick={() =>
@@ -31,7 +31,7 @@ export default class Pagination extends Component {
           }
         >
           &laquo;
-        </a>
+        </span>
       );
     }
   };
@@ -41,7 +41,7 @@ export default class Pagination extends Component {
       return <span />;
     } else {
       return (
-        <a
+        <span
           className="pagination-link"
           data-test={`pagination-page-${this.props.current - 1}`}
           onClick={() =>
@@ -49,19 +49,19 @@ export default class Pagination extends Component {
           }
         >
           {this.props.current - 1}
-        </a>
+        </span>
       );
     }
   };
 
   renderCurrentButton = () => {
     return (
-      <a
+      <span
         className="pagination-link pagination-active"
         data-test="pagination-current-page"
       >
         {this.props.current}
-      </a>
+      </span>
     );
   };
 
@@ -70,7 +70,7 @@ export default class Pagination extends Component {
       return <span />;
     } else {
       return (
-        <a
+        <span
           className="pagination-link"
           data-test={`pagination-page-${this.props.current + 1}`}
           onClick={() =>
@@ -78,7 +78,7 @@ export default class Pagination extends Component {
           }
         >
           {this.props.current + 1}
-        </a>
+        </span>
       );
     }
   };
@@ -88,7 +88,7 @@ export default class Pagination extends Component {
       return <span />;
     } else {
       return (
-        <a
+        <span
           className="pagination-link"
           data-test="pagination-right-jump"
           onClick={() =>
@@ -96,23 +96,23 @@ export default class Pagination extends Component {
           }
         >
           &raquo;
-        </a>
+        </span>
       );
     }
   };
 
   renderLastButton = () => {
-    if (this.props.current == this.props.max) {
+    if (this.props.current === this.props.max) {
       return <span />;
     } else {
       return (
-        <a
+        <span
           className="pagination-link"
           data-test="pagination-last-page"
           onClick={() => this.props.onPageSelect({ page: this.props.max })}
         >
           {this.props.max}
-        </a>
+        </span>
       );
     }
   };

--- a/src/Components/Pagination/index.js
+++ b/src/Components/Pagination/index.js
@@ -118,7 +118,7 @@ export default class Pagination extends Component {
   };
 
   render() {
-    if (this.props.max < 1) {
+    if (this.props.max === undefined || this.props.max < 1) {
       return <div className="pagination" />;
     } else {
       return (

--- a/src/Components/Pagination/index.js
+++ b/src/Components/Pagination/index.js
@@ -118,16 +118,20 @@ export default class Pagination extends Component {
   };
 
   render() {
-    return (
-      <div className="pagination">
-        {this.renderFirstButton()}
-        {this.renderLeftJumpButton()}
-        {this.renderPreviousButton()}
-        {this.renderCurrentButton()}
-        {this.renderNextButton()}
-        {this.renderRightJumpButton()}
-        {this.renderLastButton()}
-      </div>
-    );
+    if (this.props.max < 1) {
+      return <div className="pagination" />;
+    } else {
+      return (
+        <div className="pagination">
+          {this.renderFirstButton()}
+          {this.renderLeftJumpButton()}
+          {this.renderPreviousButton()}
+          {this.renderCurrentButton()}
+          {this.renderNextButton()}
+          {this.renderRightJumpButton()}
+          {this.renderLastButton()}
+        </div>
+      );
+    }
   }
 }

--- a/src/Components/Pagination/pagination.test.js
+++ b/src/Components/Pagination/pagination.test.js
@@ -18,6 +18,22 @@ describe("<Pagination>", () => {
     });
   };
 
+  describe("Given undefined pages", () => {
+    it("Doesn't display any buttons", () => {
+      pagination = new PaginationComponent({
+        current: 0,
+        max: undefined,
+        onPageSelect: () => {}
+      });
+
+      expect(pagination.displaysFirstPageButton()).toBeFalsy();
+      expect(pagination.displaysLeftJumpButton()).toBeFalsy();
+      expect(pagination.displaysCurrentButton()).toBeFalsy();
+      expect(pagination.displaysRightJumpButton()).toBeFalsy();
+      expect(pagination.displaysLastPageButton()).toBeFalsy();
+    });
+  });
+
   describe("Given 0 pages", () => {
     it("Doesn't display any buttons", () => {
       pagination = new PaginationComponent({

--- a/src/Components/Pagination/pagination.test.js
+++ b/src/Components/Pagination/pagination.test.js
@@ -18,6 +18,38 @@ describe("<Pagination>", () => {
     });
   };
 
+  describe("Given 0 pages", () => {
+    it("Doesn't display any buttons", () => {
+      pagination = new PaginationComponent({
+        current: 0,
+        max: 0,
+        onPageSelect: () => {}
+      });
+
+      expect(pagination.displaysFirstPageButton()).toBeFalsy();
+      expect(pagination.displaysLeftJumpButton()).toBeFalsy();
+      expect(pagination.displaysCurrentButton()).toBeFalsy();
+      expect(pagination.displaysRightJumpButton()).toBeFalsy();
+      expect(pagination.displaysLastPageButton()).toBeFalsy();
+    });
+  });
+
+  describe("Given 1 page", () => {
+    it("Only displays the current page button", () => {
+      pagination = new PaginationComponent({
+        current: 1,
+        max: 1,
+        onPageSelect: () => {}
+      });
+
+      expect(pagination.displaysFirstPageButton()).toBeFalsy();
+      expect(pagination.displaysLeftJumpButton()).toBeFalsy();
+      expect(pagination.displaysCurrentButton()).toBeTruthy();
+      expect(pagination.displaysRightJumpButton()).toBeFalsy();
+      expect(pagination.displaysLastPageButton()).toBeFalsy();
+    });
+  });
+
   describe("Given the selected is not within two of either end", () => {
     let pageSelectSpy;
 

--- a/src/Gateway/SearchGateway/index.js
+++ b/src/Gateway/SearchGateway/index.js
@@ -2,11 +2,14 @@ import fetch from "isomorphic-fetch";
 import Asset from "../../Domain/Asset";
 
 export default class SearchGateway {
-  async searchWithFilters(filters) {
+  async searchWithFilters(filters, page) {
     let response = await fetch(
       `${
         process.env.REACT_APP_ASSET_REGISTER_API_URL
-      }api/v1/asset/search?${this.buildQueryStringFromFilters(filters)}`
+      }api/v1/asset/search?${this.buildQueryStringFromFiltersAndPage(
+        filters,
+        page
+      )}`
     );
 
     if (response.ok) {
@@ -16,14 +19,14 @@ export default class SearchGateway {
         this.buildAssetFromResponseData(foundAsset)
       );
 
-      return assets;
+      return { assets, pages: data.pages };
     } else {
-      return [];
+      return { assets: [], pages: 0 };
     }
   }
 
-  buildQueryStringFromFilters(filters) {
-    return Object.entries(filters)
+  buildQueryStringFromFiltersAndPage(filters, page) {
+    return Object.entries({ ...filters, page })
       .map(([key, value]) => `${key}=${value}`)
       .join("&");
   }

--- a/src/Gateway/SearchGateway/searchGateway.test.js
+++ b/src/Gateway/SearchGateway/searchGateway.test.js
@@ -7,12 +7,13 @@ import {
 } from "../../../test/Fixtures/assets";
 
 describe("SearchGateway", () => {
-  let filters, gateway, searchRequest;
+  let filters, page, gateway, searchRequest;
 
   describe("Example one", () => {
     beforeEach(() => {
       process.env.REACT_APP_ASSET_REGISTER_API_URL = "http://meow.cat/";
       filters = { cat: "meow", dog: "woof" };
+      page = 5;
     });
 
     describe("Given it finds an asset", () => {
@@ -20,31 +21,49 @@ describe("SearchGateway", () => {
         let simulator = new SeachAssetSimulator("http://meow.cat/");
         searchRequest = simulator
           .searchAssetWithFilters(filters)
+          .searchAssetWithPage(page)
           .respondWithAssets([exampleAssetOne])
+          .respondWithPages(10)
           .successfully();
         gateway = new SearchGateway();
       });
 
-      it("Searches the API for the given filters", async () => {
-        await gateway.searchWithFilters(filters);
+      it("Searches the API for the given filters and page", async () => {
+        await gateway.searchWithFilters(filters, page);
+        expect(searchRequest.isDone()).toEqual(true);
+      });
+
+      it("Searches the API for the given page", async () => {
+        await gateway.searchWithFilters(filters, page);
         expect(searchRequest.isDone()).toEqual(true);
       });
 
       it("Returns the found asset", async () => {
-        let [foundAsset] = await gateway.searchWithFilters(filters);
+        let { assets } = await gateway.searchWithFilters(filters, page);
+        let foundAsset = assets[0];
 
         expect(foundAsset).toEqual(exampleAssetOne);
+      });
+
+      it("Returns the number of pages", async () => {
+        let { pages } = await gateway.searchWithFilters(filters, page);
+
+        expect(pages).toEqual(10);
       });
     });
 
     describe("Given no asset is found", () => {
       it("Returns an empty array", async () => {
         let simulator = new SeachAssetSimulator("http://meow.cat/");
-        simulator.searchAssetWithFilters(filters).unsuccessfully(404);
+        simulator
+          .searchAssetWithFilters(filters)
+          .searchAssetWithPage(page)
+          .unsuccessfully(404);
         let gateway = new SearchGateway();
 
-        let foundAssets = await gateway.searchWithFilters(filters);
-        expect(foundAssets).toEqual([]);
+        let { assets, pages } = await gateway.searchWithFilters(filters, page);
+        expect(assets).toEqual([]);
+        expect(pages).toEqual(0);
       });
     });
   });
@@ -57,6 +76,7 @@ describe("SearchGateway", () => {
         chicken: "cluck",
         dog: "woof"
       };
+      page = 10;
     });
 
     describe("Given it finds an asset", () => {
@@ -64,42 +84,62 @@ describe("SearchGateway", () => {
         let simulator = new SeachAssetSimulator("http://dog.woof/");
         searchRequest = simulator
           .searchAssetWithFilters(filters)
+          .searchAssetWithPage(page)
           .respondWithAssets([exampleAssetTwo, exampleAssetOne])
+          .respondWithPages(5)
           .successfully();
         gateway = new SearchGateway();
       });
 
       it("Searches the API for the given filters", async () => {
-        await gateway.searchWithFilters({
-          cow: "moo",
-          chicken: "cluck",
-          dog: "woof"
-        });
+        await gateway.searchWithFilters(
+          {
+            cow: "moo",
+            chicken: "cluck",
+            dog: "woof"
+          },
+          page
+        );
         expect(searchRequest.isDone()).toEqual(true);
       });
 
       it("Returns the found asset", async () => {
         let gateway = new SearchGateway();
 
-        let [assetOne, assetTwo] = await gateway.searchWithFilters({
-          cow: "moo",
-          chicken: "cluck",
-          dog: "woof"
-        });
+        let { assets } = await gateway.searchWithFilters(
+          {
+            cow: "moo",
+            chicken: "cluck",
+            dog: "woof"
+          },
+          page
+        );
+
+        let [assetOne, assetTwo] = assets;
 
         expect(assetOne).toEqual(exampleAssetTwo);
         expect(assetTwo).toEqual(exampleAssetOne);
+      });
+
+      it("Returns the number of pages", async () => {
+        let { pages } = await gateway.searchWithFilters(filters, page);
+
+        expect(pages).toEqual(5);
       });
     });
 
     describe("Given no asset is found", () => {
       it("Returns an empty array", async () => {
         let simulator = new SeachAssetSimulator("http://dog.woof/");
-        simulator.searchAssetWithFilters(filters).unsuccessfully(404);
+        simulator
+          .searchAssetWithFilters(filters)
+          .searchAssetWithPage(10)
+          .unsuccessfully(404);
         let gateway = new SearchGateway();
 
-        let foundAssets = await gateway.searchWithFilters(filters);
-        expect(foundAssets).toEqual([]);
+        let { assets, pages } = await gateway.searchWithFilters(filters, page);
+        expect(assets).toEqual([]);
+        expect(pages).toEqual(0);
       });
     });
   });

--- a/src/UseCase/SearchAssets/index.js
+++ b/src/UseCase/SearchAssets/index.js
@@ -5,7 +5,7 @@ export default class SearchAssets {
 
   async execute({ filters }) {
     let foundAssets = await this.searchGateway.searchWithFilters(filters);
-    return { assets: this.buildAssetResponseFromFoundAssets(foundAssets) };
+    return { assets: this.buildAssetResponseFromFoundAssets(foundAssets), pages: 10 };
   }
 
   buildAssetResponseFromFoundAssets(foundAssets) {

--- a/src/UseCase/SearchAssets/index.js
+++ b/src/UseCase/SearchAssets/index.js
@@ -3,9 +3,13 @@ export default class SearchAssets {
     this.searchGateway = searchGateway;
   }
 
-  async execute({ filters }) {
-    let foundAssets = await this.searchGateway.searchWithFilters(filters);
-    return { assets: this.buildAssetResponseFromFoundAssets(foundAssets), pages: 10 };
+  async execute({ filters, page }) {
+    let { assets, pages } = await this.searchGateway.searchWithFilters(filters, page);
+
+    return {
+      assets: this.buildAssetResponseFromFoundAssets(assets),
+      pages
+    };
   }
 
   buildAssetResponseFromFoundAssets(foundAssets) {

--- a/src/UseCase/SearchAssets/searchAssets.test.js
+++ b/src/UseCase/SearchAssets/searchAssets.test.js
@@ -83,21 +83,29 @@ describe("SearchAssets", () => {
   describe("Example one", () => {
     let foundAsset;
 
-    describe("Given search parameters", () => {
+    describe("Given search parameters and a page", () => {
       describe("and the search finds assets", () => {
         beforeEach(() => {
           foundAsset = buildAssetFromData(exampleAssetOne);
-          searchGatewaySpy = { searchWithFilters: jest.fn(() => [foundAsset]) };
+          searchGatewaySpy = {
+            searchWithFilters: jest.fn(() => ({ assets: [foundAsset], pages: 10 }))
+          };
           useCase = new SearchAssets({ searchGateway: searchGatewaySpy });
         });
 
         it("Calls the search gateway with the filters", async () => {
-          await useCase.execute({ filters: { cat: "meow", dog: "woof" } });
-
-          expect(searchGatewaySpy.searchWithFilters).toHaveBeenCalledWith({
-            cat: "meow",
-            dog: "woof"
+          await useCase.execute({
+            filters: { cat: "meow", dog: "woof" },
+            page: 1
           });
+
+          expect(searchGatewaySpy.searchWithFilters).toHaveBeenCalledWith(
+            {
+              cat: "meow",
+              dog: "woof"
+            },
+            1
+          );
         });
 
         it("Returns the assets from the gateway", async () => {
@@ -108,12 +116,20 @@ describe("SearchAssets", () => {
           let firstAsset = assets[0];
           expectFoundAssetToEqual(firstAsset, exampleAssetOne);
         });
+
+        it("Returns the pages from the gateway", async () => {
+          let { pages } = await useCase.execute({
+            filters: { cat: "meow", dog: "woof" }
+          });
+
+          expect(pages).toEqual(10)
+        });
       });
 
       describe("and the search does not find assets", () => {
         it("Returns an empty array", async () => {
           let searchGatewaySpy = {
-            searchWithFilters: jest.fn(() => [])
+            searchWithFilters: jest.fn(() => ({ assets: [] }))
           };
 
           let useCase = new SearchAssets({ searchGateway: searchGatewaySpy });
@@ -137,19 +153,28 @@ describe("SearchAssets", () => {
           foundAssetTwo = buildAssetFromData(exampleAssetOne);
 
           searchGatewaySpy = {
-            searchWithFilters: jest.fn(() => [foundAssetOne, foundAssetTwo])
+            searchWithFilters: jest.fn(() => ({
+              assets: [foundAssetOne, foundAssetTwo],
+              pages: 5
+            }))
           };
 
           useCase = new SearchAssets({ searchGateway: searchGatewaySpy });
         });
 
         it("Calls the search gateway with the filters", async () => {
-          await useCase.execute({ filters: { duck: "quack", cow: "moo" } });
-
-          expect(searchGatewaySpy.searchWithFilters).toHaveBeenCalledWith({
-            duck: "quack",
-            cow: "moo"
+          await useCase.execute({
+            filters: { duck: "quack", cow: "moo" },
+            page: 5
           });
+
+          expect(searchGatewaySpy.searchWithFilters).toHaveBeenCalledWith(
+            {
+              duck: "quack",
+              cow: "moo"
+            },
+            5
+          );
         });
 
         it("Returns the assets from the gateway", async () => {
@@ -162,12 +187,20 @@ describe("SearchAssets", () => {
           expectFoundAssetToEqual(firstAsset, exampleAssetTwo);
           expectFoundAssetToEqual(secondAsset, exampleAssetOne);
         });
+
+        it("Returns the pages from the gateway", async () => {
+          let { pages } = await useCase.execute({
+            filters: { duck: "quack", cow: "moo" }
+          });
+
+          expect(pages).toEqual(5);
+        });
       });
 
       describe("and the search does not find assets", () => {
         it("Returns an empty array", async () => {
           let searchGatewaySpy = {
-            searchWithFilters: jest.fn(() => [])
+            searchWithFilters: jest.fn(() => ({ assets: [] }))
           };
 
           let useCase = new SearchAssets({ searchGateway: searchGatewaySpy });

--- a/test/Simulators/SearchAsset/index.js
+++ b/test/Simulators/SearchAsset/index.js
@@ -4,10 +4,16 @@ export default class GetAsset {
   constructor(baseUrl) {
     this.baseUrl = baseUrl;
     this.responseData = {};
+    this.filters = {};
   }
 
   searchAssetWithFilters(filters) {
-    this.filters = filters;
+    this.filters = {...filters};
+    return this;
+  }
+
+  searchAssetWithPage(page) {
+    this.filters.page = page;
     return this;
   }
 
@@ -16,10 +22,15 @@ export default class GetAsset {
     return this;
   }
 
+  respondWithPages(pages) {
+    this.pages = pages
+    return this;
+  }
+
   successfully() {
     return nock(this.baseUrl)
       .get(`/api/v1/asset/search?${this.queryStringFromFilters()}`)
-      .reply(200, { data: { assets: this.assets } });
+      .reply(200, { data: { assets: this.assets, pages: this.pages } });
   }
 
   unsuccessfully(status = 500) {


### PR DESCRIPTION
What this PR does:

- Wires up the pagination to the AssetsProvider
- Shows the pagination only when there is at least one page
- Passes the page selected to the API when searching