### PR TITLE
Get Initial Search Parameters from URL

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -65,6 +65,7 @@ class App extends Component {
             <main className="govuk-main-wrapper">
               <Switch>
                 <Route exact path="/" component={SearchPage} />
+                <Route exact path="/search" component={SearchPage} />
                 <Route path="/asset/:assetId" component={AssetPage} />
               </Switch>
             </main>

--- a/src/App.js
+++ b/src/App.js
@@ -3,6 +3,8 @@ import { BrowserRouter as Router, Route, Switch, Link } from "react-router-dom";
 import "./App.css";
 import "govuk-frontend/all.scss";
 
+import HistoryGateway from "./Gateway/HistoryGateway"
+
 import SearchGateway from "./Gateway/SearchGateway";
 import SearchAssets from "./UseCase/SearchAssets";
 
@@ -26,25 +28,29 @@ const searchAssetUsecase = new SearchAssets({ searchGateway });
 const assetGateway = new AssetGateway();
 const getAssetUsecase = new GetAsset({ assetGateway });
 
-const SearchPage = props => (
-  <AssetsProvider searchAssets={searchAssetUsecase}>
-    {({ assets, onSearch, onPageSelect, numberOfPages, currentPage }) => (
-      <div className="govuk-grid-row">
-        <div className="govuk-grid-column-one-third">
-          <SearchBox onSearch={onSearch} />
+const SearchPage = props => {
+  const historyGateway = new HistoryGateway(props.history)
+
+  return (
+    <AssetsProvider history={historyGateway} searchAssets={searchAssetUsecase}>
+      {({ assets, onSearch, onPageSelect, numberOfPages, currentPage }) => (
+        <div className="govuk-grid-row">
+          <div className="govuk-grid-column-one-third">
+            <SearchBox onSearch={onSearch} />
+          </div>
+          <div className="govuk-grid-column-two-thirds">
+            <AssetList linkComponent={Link} assets={assets} />
+            <Pagination
+              onPageSelect={onPageSelect}
+              max={numberOfPages}
+              current={currentPage}
+            />
+          </div>
         </div>
-        <div className="govuk-grid-column-two-thirds">
-          <AssetList linkComponent={Link} assets={assets} />
-          <Pagination
-            onPageSelect={onPageSelect}
-            max={numberOfPages}
-            current={currentPage}
-          />
-        </div>
-      </div>
-    )}
-  </AssetsProvider>
-);
+      )}
+    </AssetsProvider>
+  );
+};
 
 const AssetPage = props => (
   <AssetProvider

--- a/src/App.js
+++ b/src/App.js
@@ -3,7 +3,9 @@ import { BrowserRouter as Router, Route, Switch, Link } from "react-router-dom";
 import "./App.css";
 import "govuk-frontend/all.scss";
 
-import HistoryGateway from "./Gateway/HistoryGateway"
+import GetInitialSearchParameters from "./UseCase/GetInitialSearchParameters";
+
+import HistoryGateway from "./Gateway/HistoryGateway";
 
 import SearchGateway from "./Gateway/SearchGateway";
 import SearchAssets from "./UseCase/SearchAssets";
@@ -28,11 +30,16 @@ const searchAssetUsecase = new SearchAssets({ searchGateway });
 const assetGateway = new AssetGateway();
 const getAssetUsecase = new GetAsset({ assetGateway });
 
+const getInitialSearchParameters = new GetInitialSearchParameters();
+
 const SearchPage = props => {
-  const historyGateway = new HistoryGateway(props.history)
+  const historyGateway = new HistoryGateway(props.history);
+  let { searchParameters, page } = getInitialSearchParameters.execute(
+    props.location.search
+  );
 
   return (
-    <AssetsProvider history={historyGateway} searchAssets={searchAssetUsecase}>
+    <AssetsProvider history={historyGateway} searchAssets={searchAssetUsecase} initialSearchParameters={{searchParameters, page}}>
       {({ assets, onSearch, onPageSelect, numberOfPages, currentPage }) => (
         <div className="govuk-grid-row">
           <div className="govuk-grid-column-one-third">

--- a/src/Components/AssetsProvider/assetsProvider.test.js
+++ b/src/Components/AssetsProvider/assetsProvider.test.js
@@ -64,7 +64,7 @@ describe("<AssetsProvider>", () => {
       childrenFake.executeOnSearch({ value: "Cats" });
 
       expect(searchAssetsSpy.execute).toHaveBeenCalledWith({
-        value: "Cats",
+        filters: { value: "Cats" },
         page: 1
       });
     });
@@ -113,7 +113,7 @@ describe("<AssetsProvider>", () => {
         await childrenFake.selectPage(3);
 
         expect(searchAssetsSpy.execute).toHaveBeenCalledWith({
-          value: "Cat",
+          filters: { value: "Cat" },
           page: 3
         });
       });
@@ -123,7 +123,7 @@ describe("<AssetsProvider>", () => {
         await childrenFake.executeOnSearch({ value: "Cat" });
 
         expect(searchAssetsSpy.execute).toHaveBeenCalledWith({
-          value: "Cat",
+          filters: { value: "Cat" },
           page: 1
         });
         expect(childrenFake.currentPageReceived).toEqual(1);
@@ -166,18 +166,18 @@ describe("<AssetsProvider>", () => {
     });
 
     it("Passes the value from the children to the searchAssets prop", () => {
-      childrenFake.executeOnSearch({ filter: "Dogs" });
+      childrenFake.executeOnSearch({ animal: "Dogs" });
 
       expect(searchAssetsSpy.execute).toHaveBeenCalledWith({
-        filter: "Dogs",
+        filters: { animal: "Dogs" },
         page: 1
       });
     });
 
     it("Stores the search parameters in the state", async () => {
-      await childrenFake.executeOnSearch({ filter: "Dogs" });
+      await childrenFake.executeOnSearch({ animal: "Dogs" });
 
-      expect(provider.state().searchParameters).toEqual({ filter: "Dogs" });
+      expect(provider.state().searchParameters).toEqual({ animal: "Dogs" });
     });
 
     it("Passes the found assets from the searchAssets prop to the children", async () => {
@@ -210,21 +210,21 @@ describe("<AssetsProvider>", () => {
       });
 
       it("Searches with the previous parameters when selecting a page", async () => {
-        await childrenFake.executeOnSearch({ filter: "Dogs" });
+        await childrenFake.executeOnSearch({ animal: "Dogs" });
         await childrenFake.selectPage(3);
 
         expect(searchAssetsSpy.execute).toHaveBeenCalledWith({
-          filter: "Dogs",
+          filters: { animal: "Dogs" },
           page: 3
         });
       });
 
       it("Resets the page to one when searching with new terms", async () => {
         await childrenFake.selectPage(5);
-        await childrenFake.executeOnSearch({ filter: "Dogs" });
+        await childrenFake.executeOnSearch({ animal: "Dogs" });
 
         expect(searchAssetsSpy.execute).toHaveBeenCalledWith({
-          filter: "Dogs",
+          filters: { animal: "Dogs" },
           page: 1
         });
         expect(childrenFake.currentPageReceived).toEqual(1);

--- a/src/Components/AssetsProvider/assetsProvider.test.js
+++ b/src/Components/AssetsProvider/assetsProvider.test.js
@@ -160,7 +160,9 @@ describe("<AssetsProvider>", () => {
         };
 
         childrenFake = new ChildrenFake();
+      });
 
+      it("Calls search assets with the initial search parameters", () => {
         provider = mount(
           <AssetsProvider
             initialSearchParameters={{
@@ -173,13 +175,25 @@ describe("<AssetsProvider>", () => {
             {childrenFake.render}
           </AssetsProvider>
         );
-      });
 
-      it("Calls search assets with the initial search parameters", () => {
         expect(searchAssetsSpy.execute).toHaveBeenCalledWith({
           filters: { dog: "woof" },
           page: 2
         });
+      });
+
+      it("Doesn't call search assets with empty initial search parameters", () => {
+        provider = mount(
+          <AssetsProvider
+            initialSearchParameters={{}}
+            history={historyGatewaySpy}
+            searchAssets={searchAssetsSpy}
+          >
+            {childrenFake.render}
+          </AssetsProvider>
+        );
+
+        expect(searchAssetsSpy.execute).not.toHaveBeenCalled();
       });
     });
   });

--- a/src/Components/AssetsProvider/index.js
+++ b/src/Components/AssetsProvider/index.js
@@ -3,6 +3,7 @@ import React, { Component } from "react";
 export default class AssetsProvider extends Component {
   constructor() {
     super();
+
     this.state = {
       assets: [],
       page: 1,
@@ -11,22 +12,39 @@ export default class AssetsProvider extends Component {
     };
   }
 
-  onSearch = async searchRequest => {
+  searchAssets = async ({ parameters, page }) => {
     let { assets, pages } = await this.props.searchAssets.execute({
-      filters: searchRequest,
-      page: 1
-    });
-    this.setState({ searchParameters: searchRequest, assets, pages, page: 1 });
-  };
-
-  onPageSelect = async ({ page }) => {
-    let { assets } = await this.props.searchAssets.execute({
-      filters: this.state.searchParameters,
+      filters: parameters,
       page
     });
 
-    this.setState({ page, assets });
+    this.setState(
+      {
+        searchParameters: parameters,
+        assets,
+        pages,
+        page
+      },
+      () => {
+        this.props.history.storeSearch({ ...parameters, page });
+      }
+    );
   };
+
+  onSearch = async searchRequest => {
+    await this.searchAssets({ parameters: searchRequest, page: 1 });
+  };
+
+  onPageSelect = async ({ page }) => {
+    await this.searchAssets({ parameters: this.state.searchParameters, page });
+  };
+
+  componentDidMount() {
+    if (this.props.initialSearchParameters) {
+      let { searchParameters, page } = this.props.initialSearchParameters;
+      this.searchAssets({ parameters: searchParameters, page });
+    }
+  }
 
   render() {
     return (

--- a/src/Components/AssetsProvider/index.js
+++ b/src/Components/AssetsProvider/index.js
@@ -13,7 +13,7 @@ export default class AssetsProvider extends Component {
 
   onSearch = async searchRequest => {
     let { assets, pages } = await this.props.searchAssets.execute({
-      ...searchRequest,
+      filters: searchRequest,
       page: 1
     });
     this.setState({ searchParameters: searchRequest, assets, pages, page: 1 });
@@ -21,7 +21,7 @@ export default class AssetsProvider extends Component {
 
   onPageSelect = async ({ page }) => {
     let { assets } = await this.props.searchAssets.execute({
-      ...this.state.searchParameters,
+      filters: this.state.searchParameters,
       page
     });
 

--- a/src/Components/AssetsProvider/index.js
+++ b/src/Components/AssetsProvider/index.js
@@ -42,7 +42,9 @@ export default class AssetsProvider extends Component {
   componentDidMount() {
     if (this.props.initialSearchParameters) {
       let { searchParameters, page } = this.props.initialSearchParameters;
-      this.searchAssets({ parameters: searchParameters, page });
+      if (searchParameters !== undefined && page !== undefined) {
+        this.searchAssets({ parameters: searchParameters, page });
+      }
     }
   }
 

--- a/src/Components/Footer/index.js
+++ b/src/Components/Footer/index.js
@@ -1,6 +1,5 @@
 import React from "react";
 import "govuk-frontend/all.scss";
-import logo from "govuk-frontend/assets/images/govuk-logotype-crown.png";
 
 export default () => (
   <footer className="govuk-footer " role="contentinfo">

--- a/src/Components/SearchBox/index.js
+++ b/src/Components/SearchBox/index.js
@@ -11,7 +11,7 @@ export default class SearchBox extends Component {
 
   onFormSubmit = e => {
     e.preventDefault();
-    this.props.onSearch({ filters: this.state.filters });
+    this.props.onSearch(this.state.filters);
   };
 
   onSearchChange = (filterName, searchValue) => {

--- a/src/Components/SearchBox/searchBox.test.js
+++ b/src/Components/SearchBox/searchBox.test.js
@@ -50,7 +50,7 @@ describe("<SearchBox>", () => {
           searchBox.submitForm();
 
           expect(onSearchSpy).toHaveBeenCalledWith({
-            filters: { schemeId: "Cats" }
+            schemeId: "Cats"
           });
         });
       });
@@ -69,7 +69,7 @@ describe("<SearchBox>", () => {
           searchBox.submitForm();
 
           expect(onSearchSpy).toHaveBeenCalledWith({
-            filters: { schemeId: "Dogs" }
+            schemeId: "Dogs"
           });
         });
       });
@@ -89,7 +89,7 @@ describe("<SearchBox>", () => {
           searchBox.submitForm();
 
           expect(onSearchSpy).toHaveBeenCalledWith({
-            filters: { address: "123 Fake Street" }
+            address: "123 Fake Street"
           });
         });
       });
@@ -108,7 +108,7 @@ describe("<SearchBox>", () => {
           searchBox.submitForm();
 
           expect(onSearchSpy).toHaveBeenCalledWith({
-            filters: { address: "Dog Town" }
+            address: "Dog Town"
           });
         });
       });
@@ -129,7 +129,8 @@ describe("<SearchBox>", () => {
           searchBox.submitForm();
 
           expect(onSearchSpy).toHaveBeenCalledWith({
-            filters: { schemeId: "12345", address: "123 Fake Street" }
+            schemeId: "12345",
+            address: "123 Fake Street"
           });
         });
       });
@@ -149,7 +150,8 @@ describe("<SearchBox>", () => {
           searchBox.submitForm();
 
           expect(onSearchSpy).toHaveBeenCalledWith({
-            filters: { schemeId: "54321", address: "Dog Town" }
+            schemeId: "54321",
+            address: "Dog Town"
           });
         });
       });

--- a/src/Gateway/HistoryGateway/historyGateway.test.js
+++ b/src/Gateway/HistoryGateway/historyGateway.test.js
@@ -1,0 +1,27 @@
+import HistoryGateway from ".";
+
+describe("HistoryGateway", () => {
+  describe("When storing the search", () => {
+    describe("Example one", () => {
+      it("Stores the search in the history", () => {
+        let historySpy = { push: jest.fn() };
+        let gateway = new HistoryGateway(historySpy);
+
+        gateway.storeSearch({ cat: "meow" });
+
+        expect(historySpy.push).toHaveBeenCalledWith("/search?cat=meow");
+      });
+    });
+
+    describe("Example one", () => {
+      it("Stores the search in the history", () => {
+        let historySpy = { push: jest.fn() };
+        let gateway = new HistoryGateway(historySpy);
+
+        gateway.storeSearch({ dog: "woof", cow: "moo", duck: "quack" });
+
+        expect(historySpy.push).toHaveBeenCalledWith("/search?dog=woof&cow=moo&duck=quack");
+      });
+    });
+  });
+});

--- a/src/Gateway/HistoryGateway/index.js
+++ b/src/Gateway/HistoryGateway/index.js
@@ -1,0 +1,15 @@
+export default class HistoryGateway {
+  constructor(history) {
+    this.history = history;
+  }
+
+  storeSearch(search) {
+    this.history.push(`/search?${this.queryStringFromSearch(search)}`);
+  }
+
+  queryStringFromSearch(search) {
+    return Object.entries(search)
+      .map(([key, value]) => `${key}=${encodeURIComponent(value)}`)
+      .join("&");
+  }
+}

--- a/src/UseCase/GetInitialSearchParameters/getInitialSearchParameters.test.js
+++ b/src/UseCase/GetInitialSearchParameters/getInitialSearchParameters.test.js
@@ -1,0 +1,51 @@
+import GetInitialSearchParameters from ".";
+
+describe("GetInitialSearchParameters", () => {
+  describe("Given an empty string", () => {
+    it("Returns an empty object", () => {
+      let useCase = new GetInitialSearchParameters();
+
+      let response = useCase.execute("");
+
+      expect(response).toEqual({});
+    });
+  });
+
+  describe("Given a query string", () => {
+    describe("Example one", () => {
+      it("Can get the search parameters", () => {
+        let useCase = new GetInitialSearchParameters();
+
+        let { searchParameters } = useCase.execute("?cat=meow&page=1");
+
+        expect(searchParameters).toEqual({ cat: "meow" });
+      });
+
+      it("Can get the page", () => {
+        let useCase = new GetInitialSearchParameters();
+
+        let { page } = useCase.execute("?cat=meow&page=1");
+
+        expect(page).toEqual(1);
+      });
+    });
+
+    describe("Example two", () => {
+      it("Can get the search parameters", () => {
+        let useCase = new GetInitialSearchParameters();
+
+        let { searchParameters } = useCase.execute("?dog=woof&cow=moo&page=5");
+
+        expect(searchParameters).toEqual({ dog: "woof", cow: "moo" });
+      });
+
+      it("Can get the page", () => {
+        let useCase = new GetInitialSearchParameters();
+
+        let { page } = useCase.execute("?dog=woof&cow=moo&page=5");
+
+        expect(page).toEqual(5);
+      });
+    });
+  });
+});

--- a/src/UseCase/GetInitialSearchParameters/index.js
+++ b/src/UseCase/GetInitialSearchParameters/index.js
@@ -1,0 +1,13 @@
+import qs from "qs";
+
+export default class GetInitialSearchParameters {
+  execute(queryString) {
+    if (queryString.length === 0) return {};
+
+    let query = qs.parse(queryString, { ignoreQueryPrefix: true });
+
+    let { page, ...searchParameters } = query;
+
+    return { searchParameters, page: parseInt(page) };
+  }
+}


### PR DESCRIPTION
What does this PR do?
- Adds the /search route
- Adds the ability to load initial results from a query string on the search route
  - `/search?address=Fake Street&page=5` - will search with the address `Fake Street` and page 5
