### PR TITLE
Adds code coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,3 +21,7 @@ storybook:
 .PHONY: test
 test: docker-down docker-build
 	docker-compose run --rm web npm test
+
+.PHONY: coverage
+coverage: docker-down docker-build
+	docker-compose run --rm web npm run coverage

--- a/package.json
+++ b/package.json
@@ -23,14 +23,14 @@
   },
   "jest": {
     "collectCoverageFrom": [
-        "**/*.{js,jsx}",
-        "!**/node_modules/**",
-        "!**/stories.js",
-        "!**/coverage/**",
-        "!**/src/index.js",
-        "!**/src/registerServiceWorker.js",
-        "!**/src/serviceWorker.js",
-        "!**/src/setupTests.js"
+      "**/*.{js,jsx}",
+      "!**/node_modules/**",
+      "!**/stories.js",
+      "!**/coverage/**",
+      "!**/src/index.js",
+      "!**/src/registerServiceWorker.js",
+      "!**/src/serviceWorker.js",
+      "!**/src/setupTests.js"
     ],
     "coverageThreshold": {
       "global": {

--- a/package.json
+++ b/package.json
@@ -17,8 +17,29 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
+    "coverage": "react-scripts test --coverage",
     "eject": "react-scripts eject",
     "storybook": "./node_modules/.bin/start-storybook -p 9009 -s public"
+  },
+  "jest": {
+    "collectCoverageFrom": [
+        "**/*.{js,jsx}",
+        "!**/node_modules/**",
+        "!**/stories.js",
+        "!**/coverage/**",
+        "!**/src/index.js",
+        "!**/src/registerServiceWorker.js",
+        "!**/src/serviceWorker.js",
+        "!**/src/setupTests.js"
+    ],
+    "coverageThreshold": {
+      "global": {
+        "branches": 90,
+        "functions": 90,
+        "statements": 90,
+        "lines": 90
+      }
+    }
   },
   "eslintConfig": {
     "extends": "react-app"


### PR DESCRIPTION
**What**

Enables code coverage (via Jest). Adds npm script and Makefile target

**Why**

The intention for enabling coverage is to identify untested code, and not as a benchmark for code actually being tested.