### PR TITLE
Enables linting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,3 +21,7 @@ storybook:
 .PHONY: test
 test: docker-down docker-build
 	docker-compose run --rm web npm test
+
+.PHONY: lint
+lint: docker-down docker-build
+	docker-compose run --rm web npm run lint

--- a/package.json
+++ b/package.json
@@ -18,11 +18,13 @@
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
-    "storybook": "./node_modules/.bin/start-storybook -p 9009 -s public"
+    "storybook": "./node_modules/.bin/start-storybook -p 9009 -s public",
+    "lint": "./node_modules/.bin/eslint src"
   },
   "eslintConfig": {
     "extends": "react-app"
   },
+  "eslintIgnore": [ "stories.js" ],
   "browserslist": [
     ">0.2%",
     "not dead",


### PR DESCRIPTION
**What**

Activates linter (eslint) and adds npm script and Makefile target.

**Why**

Linting should help identify unused variables or potentially dangerous practices (eval). We've opted for the linter ruleset as used by the `create-react-app` project as this is a bit more lenient compared to other rule sets.