### PR TITLE
Add maps proof of concept page

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,18 @@ make serve
 make test
 ```
 
+### With google maps API
+
+If you wish to run the application with the `/maps` route, you need a valid google maps API key. 
+
+To run it with your api key, use the following command:
+
+```bash
+env MAP_API_KEY=<apiKey> make serve
+```
+
+docker-compose will then pull your api key through into the application to use with the Google Maps API
+
 ## Architecture Decision Records
 
 In order to provide context around some of our architecture decisions, we have documented them inside [./ArchitectureDecisionRecords](ArchitectureDecisionRecords).

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -15,6 +15,7 @@ if [ "${ENVIRONMENT_NAME}" == "production" ]; then
 else
   APP_NAME="${ENVIRONMENT_NAME}"
   REACT_APP_ASSET_REGISTER_API_URL="${API_URL_STAGING}"
+  DISPLAY_MAPS=yes
 fi
 
 curl -L "https://packages.cloudfoundry.org/stable?release=linux64-binary&source=github" | tar -zx
@@ -26,5 +27,7 @@ curl -L "https://packages.cloudfoundry.org/stable?release=linux64-binary&source=
 ./cf set-env "asset-register-frontend-${APP_NAME}" circle_commit "${CIRCLE_SHA1}"
 ./cf set-env "asset-register-frontend-${APP_NAME}" REACT_APP_SENTRY_DSN "${SENTRY_DSN}"
 ./cf set-env "asset-register-frontend-${APP_NAME}" REACT_APP_ASSET_REGISTER_API_URL "${REACT_APP_ASSET_REGISTER_API_URL}"
+./cf set-env "asset-register-frontend-${APP_NAME}" REACT_APP_DISPLAY_MAPS "${DISPLAY_MAPS}"
+./cf set-env "asset-register-frontend-${APP_NAME}" REACT_APP_MAPS_API_KEY "${MAPS_API_KEY}"
 
 ./cf push -f "deploy-manifests/${APP_NAME}.yml"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,3 +21,5 @@ services:
     privileged: true
     environment:
       - REACT_APP_ASSET_REGISTER_API_URL=http://localhost:5000/
+      - REACT_APP_DISPLAY_MAPS=yes
+      - REACT_APP_MAPS_API_KEY=${MAP_API_KEY}

--- a/package-lock.json
+++ b/package-lock.json
@@ -4915,6 +4915,11 @@
         }
       }
     },
+    "can-use-dom": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/can-use-dom/-/can-use-dom-0.1.0.tgz",
+      "integrity": "sha1-IsxKNKCrxDlQ9CxkEQJKP2NmtFo="
+    },
     "caniuse-api": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-3.0.0.tgz",
@@ -4972,6 +4977,11 @@
         "escape-string-regexp": "^1.0.5",
         "supports-color": "^5.3.0"
       }
+    },
+    "change-emitter": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/change-emitter/-/change-emitter-0.1.6.tgz",
+      "integrity": "sha1-6LL+PX8at9aaMhma/5HqaTFAlRU="
     },
     "chardet": {
       "version": "0.7.0",
@@ -6537,7 +6547,6 @@
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
       "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
-      "dev": true,
       "requires": {
         "iconv-lite": "~0.4.13"
       }
@@ -7673,7 +7682,6 @@
       "version": "0.8.17",
       "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
       "integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
-      "dev": true,
       "requires": {
         "core-js": "^1.0.0",
         "isomorphic-fetch": "^2.1.1",
@@ -7687,14 +7695,12 @@
         "core-js": {
           "version": "1.2.7",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
-          "dev": true
+          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
         },
         "promise": {
           "version": "7.3.1",
           "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
           "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
-          "dev": true,
           "requires": {
             "asap": "~2.0.3"
           }
@@ -8727,6 +8733,16 @@
         "lodash": "~4.17.10",
         "minimatch": "~3.0.2"
       }
+    },
+    "google-maps-infobox": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/google-maps-infobox/-/google-maps-infobox-2.0.0.tgz",
+      "integrity": "sha512-hTuWmWZZSOxf5D/z7l3/hTF1grgRvLG53BEKMdjiKOG+FcK/kH7vqseUeyIU9Zj2ZIqKTOaro0nknxpAuRq4Vw=="
+    },
+    "google-maps-react": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/google-maps-react/-/google-maps-react-2.0.2.tgz",
+      "integrity": "sha512-6cYauGwt22haDUrWxKQ6yoNOqjiuxHo8YYcmb+aBvNICokdXmZOUB6Ah4vD5VexMVlrwP2PFqA/D8sHpEB52KA=="
     },
     "govuk-frontend": {
       "version": "2.4.0",
@@ -10018,7 +10034,6 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
       "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
-      "dev": true,
       "requires": {
         "node-fetch": "^1.0.1",
         "whatwg-fetch": ">=0.10.0"
@@ -11191,6 +11206,16 @@
         "object-visit": "^1.0.0"
       }
     },
+    "marker-clusterer-plus": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/marker-clusterer-plus/-/marker-clusterer-plus-2.1.4.tgz",
+      "integrity": "sha1-+O/3TVmdqzt9Dj/tUmTqDnBPXWc="
+    },
+    "markerwithlabel": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/markerwithlabel/-/markerwithlabel-2.0.2.tgz",
+      "integrity": "sha512-C/cbm1A0h/u54gwHk5ZJNdUU3V3+1BbCpRPMsMyFA7vF4yL+aB4rWpxACz29TpQ+cTg6/iQroExh0PMSRGtQFg=="
+    },
     "math-random": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
@@ -11668,7 +11693,6 @@
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
       "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-      "dev": true,
       "requires": {
         "encoding": "^0.1.11",
         "is-stream": "^1.0.1"
@@ -15204,6 +15228,24 @@
         "prop-types": "^15.5.9"
       }
     },
+    "react-google-maps": {
+      "version": "9.4.5",
+      "resolved": "https://registry.npmjs.org/react-google-maps/-/react-google-maps-9.4.5.tgz",
+      "integrity": "sha512-8z5nX9DxIcBCXuEiurmRT1VXVwnzx0C6+3Es6lxB2/OyY2SLax2/LcDu6Aldxnl3HegefTL7NJzGeaKAJ61pOA==",
+      "requires": {
+        "babel-runtime": "^6.11.6",
+        "can-use-dom": "^0.1.0",
+        "google-maps-infobox": "^2.0.0",
+        "invariant": "^2.2.1",
+        "lodash": "^4.16.2",
+        "marker-clusterer-plus": "^2.1.4",
+        "markerwithlabel": "^2.0.1",
+        "prop-types": "^15.5.8",
+        "recompose": "^0.26.0",
+        "scriptjs": "^2.5.8",
+        "warning": "^3.0.0"
+      }
+    },
     "react-inspector": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/react-inspector/-/react-inspector-2.3.0.tgz",
@@ -15807,6 +15849,24 @@
       "dev": true,
       "requires": {
         "resolve": "^1.1.6"
+      }
+    },
+    "recompose": {
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/recompose/-/recompose-0.26.0.tgz",
+      "integrity": "sha512-KwOu6ztO0mN5vy3+zDcc45lgnaUoaQse/a5yLVqtzTK13czSWnFGmXbQVmnoMgDkI5POd1EwIKSbjU1V7xdZog==",
+      "requires": {
+        "change-emitter": "^0.1.2",
+        "fbjs": "^0.8.1",
+        "hoist-non-react-statics": "^2.3.1",
+        "symbol-observable": "^1.0.4"
+      },
+      "dependencies": {
+        "hoist-non-react-statics": {
+          "version": "2.5.5",
+          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
+          "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
+        }
       }
     },
     "recursive-readdir": {
@@ -16703,6 +16763,11 @@
           "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
         }
       }
+    },
+    "scriptjs": {
+      "version": "2.5.9",
+      "resolved": "https://registry.npmjs.org/scriptjs/-/scriptjs-2.5.9.tgz",
+      "integrity": "sha512-qGVDoreyYiP1pkQnbnFAUIS5AjenNwwQBdl7zeos9etl+hYKWahjRTfzAZZYBv5xNHx7vNKCmaLDQZ6Fr2AEXg=="
     },
     "scss-tokenizer": {
       "version": "0.2.3",
@@ -17805,8 +17870,7 @@
     "symbol-observable": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
-      "dev": true
+      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
     },
     "symbol-tree": {
       "version": "3.2.2",
@@ -18239,8 +18303,7 @@
     "ua-parser-js": {
       "version": "0.7.19",
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.19.tgz",
-      "integrity": "sha512-T3PVJ6uz8i0HzPxOF9SWzWAlfN/DavlpQqepn22xgve/5QecC+XMCAtmUNnY7C9StehaV6exjUCI801lOI7QlQ==",
-      "dev": true
+      "integrity": "sha512-T3PVJ6uz8i0HzPxOF9SWzWAlfN/DavlpQqepn22xgve/5QecC+XMCAtmUNnY7C9StehaV6exjUCI801lOI7QlQ=="
     },
     "uglify-js": {
       "version": "3.4.9",

--- a/package.json
+++ b/package.json
@@ -5,12 +5,14 @@
   "dependencies": {
     "@sentry/browser": "^4.3.4",
     "cross-fetch": "^3.0.0",
+    "google-maps-react": "^2.0.2",
     "govuk-frontend": "^2.4.0",
     "js-file-download": "^0.4.4",
     "moment": "^2.22.2",
     "node-sass": "^4.10.0",
     "react": "^16.6.3",
     "react-dom": "^16.6.3",
+    "react-google-maps": "^9.4.5",
     "react-router-dom": "^4.3.1",
     "react-scripts": "2.0.5"
   },

--- a/src/App.js
+++ b/src/App.js
@@ -3,7 +3,7 @@ import { BrowserRouter as Router, Route, Switch, Link } from "react-router-dom";
 import "./App.css";
 import "govuk-frontend/all.scss";
 
-import Login from "./Components/Login";
+import ClusteredMap from "./Components/ClusteredMap";
 
 import FileDownloadPresenter from "./Presenters/FileDownload";
 
@@ -48,6 +48,12 @@ const aggregateGateway = new AggregateGateway();
 const getAggregateValuesUseCase = new GetAggregateValues({ aggregateGateway });
 
 const fileDownloadPresenter = new FileDownloadPresenter();
+
+const displayMapsPage = () => {
+  console.log(process.env.REACT_APP_DISPLAY_MAPS);
+
+  return process.env.REACT_APP_DISPLAY_MAPS === "yes";
+};
 
 const LandingPage = () => {
   return (
@@ -282,6 +288,14 @@ class App extends Component {
                 <Route exact path="/" component={LandingPage} />
                 <Route exact path="/search" component={SearchPage} />
                 <Route path="/asset/:assetId" component={AssetPage} />
+                {displayMapsPage() && (
+                  <Route
+                    path="/maps/:positions"
+                    component={props => (
+                      <ClusteredMap positions={props.match.params.positions} />
+                    )}
+                  />
+                )}
               </Switch>
             </main>
           </div>

--- a/src/Components/ClusteredMap/index.js
+++ b/src/Components/ClusteredMap/index.js
@@ -17,12 +17,12 @@ const generateRandomLong = () => {
 };
 
 const generateRandomLat = () => {
-  var num = (Math.random() * 3).toFixed(3);
+  var num = (Math.random() * 3.5).toFixed(3);
   var posorneg = Math.floor(Math.random());
   if (posorneg === 0) {
     num = num * -1;
   }
-  return num + 54;
+  return num + 54.5;
 };
 
 const generatePositions = num => {
@@ -41,10 +41,10 @@ const MapWithAMarker = withScriptjs(
     return (
       <GoogleMap
         defaultOptions={{ disableDefaultUI: true, mapTypeControl: false }}
-        defaultZoom={6}
-        defaultCenter={{ lat: 53.5, lng: -0.0 }}
+        defaultZoom={7}
+        defaultCenter={{ lat: 52.8, lng: -1.0 }}
       >
-        <MarkerClusterer gridSize={60}>
+        <MarkerClusterer gridSize={70}>
           {positions.map(pos => (
             <Marker key={JSON.stringify(pos)} position={pos} />
           ))}
@@ -61,7 +61,7 @@ export default props => (
       process.env.REACT_APP_MAPS_API_KEY
     }&v=3.exp&libraries=geometry,drawing,places`}
     loadingElement={<div>loading</div>}
-    containerElement={<div style={{ height: `600px` }} />}
+    containerElement={<div style={{ height: `800px` }} />}
     mapElement={<div style={{ height: `100%` }} />}
   />
 );

--- a/src/Components/ClusteredMap/index.js
+++ b/src/Components/ClusteredMap/index.js
@@ -1,0 +1,67 @@
+import React, { Component } from "react";
+import {
+  withScriptjs,
+  withGoogleMap,
+  GoogleMap,
+  Marker
+} from "react-google-maps";
+import { MarkerClusterer } from "react-google-maps/lib/components/addons/MarkerClusterer";
+
+const generateRandomLong = () => {
+  var num = (Math.random() * 3).toFixed(3);
+  var posorneg = Math.floor(Math.random());
+  if (posorneg === 0) {
+    num = num * -1;
+  }
+  return num;
+};
+
+const generateRandomLat = () => {
+  var num = (Math.random() * 3).toFixed(3);
+  var posorneg = Math.floor(Math.random());
+  if (posorneg === 0) {
+    num = num * -1;
+  }
+  return num + 54;
+};
+
+const generatePositions = num => {
+  let positions = [];
+  for (let i = 0; i < num; i++) {
+    positions.push({ lat: generateRandomLat(), lng: generateRandomLong() });
+  }
+  return positions;
+};
+
+const MapWithAMarker = withScriptjs(
+  withGoogleMap(props => {
+    console.log("generating positions");
+    const positions = generatePositions(props.positions);
+    console.log("Positions generated");
+    return (
+      <GoogleMap
+        defaultOptions={{ disableDefaultUI: true, mapTypeControl: false }}
+        defaultZoom={6}
+        defaultCenter={{ lat: 53.5, lng: -0.0 }}
+      >
+        <MarkerClusterer gridSize={60}>
+          {positions.map(pos => (
+            <Marker key={JSON.stringify(pos)} position={pos} />
+          ))}
+        </MarkerClusterer>
+      </GoogleMap>
+    );
+  })
+);
+
+export default props => (
+  <MapWithAMarker
+    positions={props.positions}
+    googleMapURL={`https://maps.googleapis.com/maps/api/js?key=${
+      process.env.REACT_APP_MAPS_API_KEY
+    }&v=3.exp&libraries=geometry,drawing,places`}
+    loadingElement={<div>loading</div>}
+    containerElement={<div style={{ height: `600px` }} />}
+    mapElement={<div style={{ height: `100%` }} />}
+  />
+);


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/976254/51121868-608e6980-1810-11e9-848a-fc33ad7f2bef.png)

This PR adds a `/maps/:positions` route - which allows us to demonstrate a google maps clustering page with a varied number of positions