### PR TITLE
Add clustered map below search results

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -168,7 +168,26 @@ const renderAssetRegisterReporting = (
         max={numberOfPages}
         current={currentPage}
       />
+      {renderAssetsMap(assets, searchParameters)}
     </div>
+  );
+};
+
+const renderAssetsMap = (assets, searchParameters) => {
+  if (assets.length === 0) {
+    return <div />;
+  }
+  const postcodes = assets.map(({ propertyPostcode }) => propertyPostcode);
+  return (
+    <CoordinateProvider
+      key={JSON.stringify(searchParameters)}
+      postcodes={postcodes}
+      getCoordinatesForPostcode={getCoordinatesForPostcode}
+    >
+      {({ coordinates }) => {
+        return <ClusteredMap positions={coordinates} />;
+      }}
+    </CoordinateProvider>
   );
 };
 
@@ -272,9 +291,9 @@ const AssetPage = props => (
               postcodes={[postcode]}
               getCoordinatesForPostcode={getCoordinatesForPostcode}
             >
-              {({ coordinates}) => { 
-                console.log(coordinates)
-                return <AssetMap position={coordinates[0]} />}}
+              {({ coordinates }) => {
+                return <AssetMap position={coordinates[0]} />;
+              }}
             </CoordinateProvider>
           )}
         />

--- a/src/Components/ClusteredMap/index.js
+++ b/src/Components/ClusteredMap/index.js
@@ -35,9 +35,6 @@ const generatePositions = num => {
 
 const MapWithAMarker = withScriptjs(
   withGoogleMap(props => {
-    console.log("generating positions");
-    const positions = generatePositions(props.positions);
-    console.log("Positions generated");
     return (
       <GoogleMap
         defaultOptions={{ disableDefaultUI: true, mapTypeControl: false }}
@@ -45,7 +42,7 @@ const MapWithAMarker = withScriptjs(
         defaultCenter={{ lat: 52.8, lng: -1.0 }}
       >
         <MarkerClusterer gridSize={70}>
-          {positions.map(pos => (
+          {props.positions.map(pos => (
             <Marker key={JSON.stringify(pos)} position={pos} />
           ))}
         </MarkerClusterer>


### PR DESCRIPTION
What does this PR do:

- Uses existing components to place a clustered map of the **current page** of search results below the list of results

What needs to be worked on following this PR:
- Pull in the remaining pages of the search results in order to display all of them on a map

![image](https://user-images.githubusercontent.com/976254/51196993-42943800-18e8-11e9-819d-ecb127883faa.png)